### PR TITLE
# add filename support for GZIPCompressedStream

### DIFF
--- a/gzip_stream.py
+++ b/gzip_stream.py
@@ -17,7 +17,7 @@ class GZIPCompressedStream(io.RawIOBase):
 
         self._compressed_stream = io.BytesIO()
         self._compressor = gzip.GzipFile(
-            filename=file_name,
+            filename=filename,
             mode='wb',
             fileobj=self._compressed_stream,
             compresslevel=compression_level

--- a/gzip_stream.py
+++ b/gzip_stream.py
@@ -8,7 +8,7 @@ from typing import BinaryIO
 
 
 class GZIPCompressedStream(io.RawIOBase):
-    def __init__(self, stream: BinaryIO, *, compression_level: int):
+    def __init__(self, stream: BinaryIO, *, compression_level: int, file_name: str=None):
         assert 1 <= compression_level <= 9
 
         self._compression_level = compression_level
@@ -16,6 +16,7 @@ class GZIPCompressedStream(io.RawIOBase):
 
         self._compressed_stream = io.BytesIO()
         self._compressor = gzip.GzipFile(
+            filename=file_name,
             mode='wb',
             fileobj=self._compressed_stream,
             compresslevel=compression_level

--- a/gzip_stream.py
+++ b/gzip_stream.py
@@ -9,7 +9,7 @@ from typing import BinaryIO
 
 class GZIPCompressedStream(io.RawIOBase):
     def __init__(self, stream: BinaryIO, *, compression_level: int,
-                 file_name: str = None):
+                 filename: str = None):
         assert 1 <= compression_level <= 9
 
         self._compression_level = compression_level

--- a/gzip_stream.py
+++ b/gzip_stream.py
@@ -9,7 +9,7 @@ from typing import BinaryIO
 
 class GZIPCompressedStream(io.RawIOBase):
     def __init__(self, stream: BinaryIO, *, compression_level: int,
-                 file_name: str=None):
+                 file_name: str = None):
         assert 1 <= compression_level <= 9
 
         self._compression_level = compression_level

--- a/gzip_stream.py
+++ b/gzip_stream.py
@@ -8,7 +8,8 @@ from typing import BinaryIO
 
 
 class GZIPCompressedStream(io.RawIOBase):
-    def __init__(self, stream: BinaryIO, *, compression_level: int, file_name: str=None):
+    def __init__(self, stream: BinaryIO, *, compression_level: int,
+                 file_name: str=None):
         assert 1 <= compression_level <= 9
 
         self._compression_level = compression_level


### PR DESCRIPTION
ADDED:
 - new parameter "file_name" which enables naming of the compressed stream

MODIFIED:
 - incorporated "file_name" in the constructor call "gzip.GzipFile"

REMOVED:
 - nothing