### PR TITLE
[tests] Replace `aiomisc` with `pytest-asyncio` in tox testenv deps

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -51,6 +51,7 @@ class FakeAsyncReader(BaseAsyncIteratorReader):
     ids=['0 bytes', '1 bytes', '4 bytes',
          'fake text - ~4 KB', 'fake text - ~256 KB']
 )
+@pytest.mark.asyncio
 async def test_gzip_aiter_async_reader(expected, tmpdir):
     tmp_file = tmpdir / 'temp.txt'
     with gzip.open(str(tmp_file), 'wb') as f:
@@ -75,6 +76,7 @@ async def test_gzip_aiter_async_reader(expected, tmpdir):
     ids=['2 bytes', '4 bytes', '8 bytes',
          '16 bytes', '1 KB']
 )
+@pytest.mark.asyncio
 async def test_buffer_gzip_async_reader(tmpdir, buff_size):
     plain_text = 'hello world' * 1000
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ envlist = lint,py3{5,6,7,8,9}
 
 [testenv]
 deps =
-    aiomisc
     faker
     pytest
+    pytest-asyncio
     pytest-cov
 commands =
     pytest \


### PR DESCRIPTION
`aiomisc` dropped Python 3.5 support, so tests on Python 3.5 were failing.
This commit replaces it with `pytest-asyncio`.